### PR TITLE
fix: make common keyboard shortcuts work

### DIFF
--- a/app/components/Editor.css
+++ b/app/components/Editor.css
@@ -40,6 +40,7 @@ const styles = css(`
 		text-shadow: 0px 0px 0px #000;
 		width: 100%;
 		-webkit-text-fill-color: transparent;
+		-webkit-user-select: default;
 	}
 `);
 


### PR DESCRIPTION
The mechanism for disabling user selection (highlighting text) also effected the `Editor` component.